### PR TITLE
feat: add navigation bar to study group list

### DIFF
--- a/src/components/StudyGroup/StudyGroupList.vue
+++ b/src/components/StudyGroup/StudyGroupList.vue
@@ -1,29 +1,78 @@
 <template>
   <GlobalLoader />
   <v-container v-if="!isLoading">
-    <div v-if="groups.length === 0" class="empty-state">
+    <div class="group-nav-bar">
+      <div class="nav-items">
+        <button
+          v-for="item in navItems"
+          :key="item.value"
+          :class="['nav-item', { active: activeNav === item.value }]"
+          @click="setActiveNav(item.value)"
+        >
+          {{ item.label }}
+        </button>
+      </div>
+      <div class="nav-actions">
+        <div class="search-wrapper">
+          <input
+            v-model="searchQuery"
+            class="search-bar"
+            type="text"
+            placeholder="搜索学习小组"
+            @input="onSearchInput"
+          />
+          <ul v-if="showSuggestions" class="search-suggestions">
+            <li
+              v-for="s in suggestions"
+              :key="s.id"
+              @click="selectSuggestion(s.name)"
+            >
+              {{ s.name }}
+            </li>
+          </ul>
+        </div>
+        <button class="search-btn" @click="performSearch">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="20"
+            height="20"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            <circle cx="11" cy="11" r="8"></circle>
+            <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
+          </svg>
+        </button>
+        <button class="create-group-btn" @click="toCreateGroupPage">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            x="0px"
+            y="0px"
+            width="24"
+            height="24"
+            viewBox="0 0 32 32"
+          >
+            <path
+              d="M 12 2 C 6.4889971 2 2 6.4889971 2 12 C 2 17.511003 6.4889971 22 12 22 C 17.511003 22 22 17.511003 22 12 C 22 6.4889971 17.511003 2 12 2 z M 12 4 C 16.430123 4 20 7.5698774 20 12 C 20 16.430123 16.430123 20 12 20 C 7.5698774 20 4 16.430123 4 12 C 4 7.5698774 7.5698774 4 12 4 z M 11 7 L 11 11 L 7 11 L 7 13 L 11 13 L 11 17 L 13 17 L 13 13 L 17 13 L 17 11 L 13 11 L 13 7 L 11 7 z"
+            ></path>
+          </svg>
+          创建学习小组
+        </button>
+      </div>
+    </div>
+    <div v-if="filteredGroups.length === 0" class="empty-state">
       <p>
         暂时没有学习小组，去
         <button @click="toCreateGroupPage">创建</button>
         第一个吧！
       </p>
     </div>
-    <button class="create-group-btn" @click="toCreateGroupPage">
-      <svg
-        xmlns="http://www.w3.org/2000/svg"
-        x="0px"
-        y="0px"
-        width="32"
-        height="32"
-        viewBox="0 0 32 32"
-      >
-        <path
-          d="M 12 2 C 6.4889971 2 2 6.4889971 2 12 C 2 17.511003 6.4889971 22 12 22 C 17.511003 22 22 17.511003 22 12 C 22 6.4889971 17.511003 2 12 2 z M 12 4 C 16.430123 4 20 7.5698774 20 12 C 20 16.430123 16.430123 20 12 20 C 7.5698774 20 4 16.430123 4 12 C 4 7.5698774 7.5698774 4 12 4 z M 11 7 L 11 11 L 7 11 L 7 13 L 11 13 L 11 17 L 13 17 L 13 13 L 17 13 L 17 11 L 13 11 L 13 7 L 11 7 z"
-        ></path></svg
-      >创建学习小组
-    </button>
     <div ref="masonryContainer" class="masonry-container">
-      <div v-for="group in groups" :key="group.id" class="masonry-item">
+      <div v-for="group in filteredGroups" :key="group.id" class="masonry-item">
         <v-card class="st-card">
           <v-img
             class="group-image"
@@ -103,10 +152,50 @@ export default {
     return {
       groups: [], // This will be filled with data from the mock file or the backend
       masonryInstance: null,
+      navItems: [
+        { label: '推荐', value: 'recommend' },
+        { label: '已加入', value: 'joined' },
+        { label: '关注', value: 'follow' },
+        { label: '科普', value: 'popular' },
+        { label: '编程', value: 'coding' },
+        { label: '哲学', value: 'philosophy' },
+        { label: '更多', value: 'more' },
+      ],
+      activeNav: 'recommend',
+      searchQuery: '',
+      searchTerm: '',
+      showSuggestions: false,
     }
+  },
+  computed: {
+    filteredGroups() {
+      if (!this.searchTerm) return this.groups
+      const query = this.searchTerm.toLowerCase()
+      return this.groups.filter((g) => g.name.toLowerCase().includes(query))
+    },
+    suggestions() {
+      if (!this.searchQuery) return []
+      const query = this.searchQuery.toLowerCase()
+      return this.groups.filter((g) => g.name.toLowerCase().includes(query))
+    },
   },
   methods: {
     ...mapActions(['goToProfile']),
+
+    setActiveNav(value) {
+      this.activeNav = value
+    },
+    onSearchInput() {
+      this.showSuggestions = !!this.searchQuery
+    },
+    performSearch() {
+      this.searchTerm = this.searchQuery
+      this.showSuggestions = false
+    },
+    selectSuggestion(name) {
+      this.searchQuery = name
+      this.performSearch()
+    },
 
     initMasonry() {
       // Initialize Masonry
@@ -168,6 +257,15 @@ export default {
       this.goToProfile({ userId, router: this.$router })
     },
   },
+  watch: {
+    searchTerm() {
+      this.$nextTick(() => {
+        if (this.masonryInstance) {
+          this.masonryInstance.layout()
+        }
+      })
+    },
+  },
   mounted() {
     this.fetchGroups()
     this.$nextTick(() => {
@@ -184,6 +282,86 @@ export default {
 
 <style scoped>
 @import '../../assets/css/avatar.css';
+
+/* Top navigation bar */
+.group-nav-bar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 16px;
+  flex-wrap: wrap;
+}
+
+.nav-items {
+  display: flex;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.nav-actions {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.search-wrapper {
+  position: relative;
+}
+
+.search-bar {
+  padding: 6px 12px;
+  border: 1px solid #ccc;
+  border-radius: 16px;
+  font-size: 14px;
+}
+
+.search-suggestions {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  background: #fff;
+  border: 1px solid #ccc;
+  border-top: none;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  max-height: 150px;
+  overflow-y: auto;
+  z-index: 10;
+}
+
+.search-suggestions li {
+  padding: 4px 8px;
+  cursor: pointer;
+}
+
+.search-suggestions li:hover {
+  background-color: #f0f0f0;
+}
+
+.search-btn {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 4px;
+  display: flex;
+  align-items: center;
+}
+
+.nav-item {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 16px;
+  color: #1c2b42;
+  padding: 4px 0;
+}
+
+.nav-item.active {
+  border-bottom: 2px solid #1c2b42;
+  font-weight: bold;
+}
 
 /* Container for masonry layout */
 .masonry-container {
@@ -244,23 +422,25 @@ export default {
 
 /* Create group button */
 .create-group-btn {
-  position: fixed;
-  top: 20vh;
-  right: 4vw;
+  display: flex;
+  align-items: center;
   background-color: #dfcba4;
   border: 1px solid #faf6f0;
   box-shadow: 0 4px 10px 0px #faf6f0;
-  padding: 20px 10px 20px 10px;
+  padding: 8px 12px;
   border-radius: 16px;
-  writing-mode: vertical-rl;
-  text-orientation: upright;
-  font-size: 18px;
+  font-size: 16px;
+  cursor: pointer;
+}
 
-  &:hover {
-    transform: scale(1.05);
-    transition: transform 0.2s ease-in-out;
-    border: 2px solid #faf6f0;
-    box-shadow: 0 4px 10px 1px #faf6f0;
-  }
+.create-group-btn svg {
+  margin-right: 4px;
+}
+
+.create-group-btn:hover {
+  transform: scale(1.05);
+  transition: transform 0.2s ease-in-out;
+  border: 2px solid #faf6f0;
+  box-shadow: 0 4px 10px 1px #faf6f0;
 }
 </style>


### PR DESCRIPTION
## Summary
- add top navigation bar with category tabs and create-group button on study group list page
- add right-aligned search bar with magnifying button and dropdown suggestions
- style search suggestions and button

## Testing
- `npm run lint` *(fails: numerous prettier violations across project)*
- `npx eslint src/components/StudyGroup/StudyGroupList.vue`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ac30475f5c832ebf7f441a2a9851b9