### PR TITLE
feat: add study plan workspace

### DIFF
--- a/src/components/HeaderBar.vue
+++ b/src/components/HeaderBar.vue
@@ -165,7 +165,7 @@ export default {
       if (!this.isAuthenticated) {
         alert('请先登录再查看学习计划')
       } else {
-        this.$emit('showStudyPlanDialog', true)
+        this.$router.push({ name: 'StudyPlanWorkspace' })
       }
     },
     toggleLanguage() {

--- a/src/components/StudyPlanList.vue
+++ b/src/components/StudyPlanList.vue
@@ -182,8 +182,8 @@ export default {
   methods: {
     goToPlanDetail(planId) {
       this.$router.push({
-        name: 'StudyPlanDetail',
-        params: { studyPlanId: planId, userId: this.userId },
+        name: 'StudyPlanWorkspace',
+        query: { planId },
       })
     },
   },

--- a/src/components/StudyPlanWorkspace.vue
+++ b/src/components/StudyPlanWorkspace.vue
@@ -1,0 +1,141 @@
+<template>
+  <v-container fluid class="study-plan-workspace">
+    <v-row no-gutters>
+      <!-- Left column: list of study plans -->
+      <v-col cols="3" class="left-panel">
+        <v-list nav dense>
+          <v-list-item
+            v-for="plan in studyPlans"
+            :key="plan.studyPlan.id"
+            @click="selectPlan(plan.studyPlan)"
+            :class="{ 'selected-plan': currentPlan && currentPlan.id === plan.studyPlan.id }"
+          >
+            <v-list-item-title>{{ plan.studyPlan.title }}</v-list-item-title>
+            <v-progress-linear
+              :model-value="plan.studyPlan.progressPercentage"
+              height="6"
+              color="primary"
+            />
+          </v-list-item>
+        </v-list>
+      </v-col>
+
+      <!-- Middle column: lessons graph (simplified timeline) -->
+      <v-col cols="5" class="center-panel">
+        <div v-if="currentPlan">
+          <v-timeline density="compact">
+            <v-timeline-item
+              v-for="(lesson, index) in currentPlan.mainCurriculum"
+              :key="index"
+              :title="lesson.name"
+              :class="{ 'selected-lesson': currentLesson && currentLesson.name === lesson.name }"
+              @click="selectLesson(lesson)"
+            />
+          </v-timeline>
+        </div>
+        <div v-else class="placeholder">请选择一个学习计划</div>
+      </v-col>
+
+      <!-- Right column: lesson content -->
+      <v-col cols="4" class="right-panel">
+        <div v-if="currentLesson">
+          <h3>{{ currentLesson.name }}</h3>
+          <p>{{ currentLesson.description }}</p>
+          <div v-if="currentLesson.resources && currentLesson.resources.length">
+            <div
+              v-for="(res, idx) in currentLesson.resources"
+              :key="idx"
+              class="resource-link"
+            >
+              <a :href="res.link" target="_blank">{{ res.link }}</a>
+            </div>
+          </div>
+        </div>
+        <div v-else class="placeholder">请选择一个课程</div>
+      </v-col>
+    </v-row>
+  </v-container>
+</template>
+
+<script>
+import apiClient from '@/api'
+
+export default {
+  name: 'StudyPlanWorkspace',
+  data() {
+    return {
+      studyPlans: [],
+      currentPlan: null,
+      currentLesson: null,
+    }
+  },
+  async created() {
+    await this.fetchPlans()
+    const planId = this.$route.query.planId
+    if (planId) {
+      const selected = this.studyPlans.find(
+        (p) => String(p.studyPlan.id) === String(planId)
+      )
+      if (selected) {
+        this.selectPlan(selected.studyPlan)
+      }
+    }
+  },
+  methods: {
+    async fetchPlans() {
+      try {
+        const res = await apiClient.get(`/StudyPlan/FetchStudyPlans`)
+        this.studyPlans = res.data
+      } catch (e) {
+        console.error('Error fetching study plans:', e)
+      }
+    },
+    selectPlan(plan) {
+      this.currentPlan = plan
+      this.currentLesson = plan.mainCurriculum[0] || null
+    },
+    selectLesson(lesson) {
+      this.currentLesson = lesson
+    },
+  },
+}
+</script>
+
+<style scoped>
+.study-plan-workspace {
+  background-color: #f4eee1;
+  height: calc(100vh - 64px);
+}
+.left-panel {
+  border-right: 1px solid #ccc;
+  overflow-y: auto;
+  max-height: 100%;
+}
+.center-panel {
+  border-right: 1px solid #ccc;
+  overflow-y: auto;
+  max-height: 100%;
+  display: flex;
+  justify-content: center;
+}
+.right-panel {
+  overflow-y: auto;
+  max-height: 100%;
+  padding: 16px;
+}
+.selected-plan {
+  background-color: #e0e0e0;
+}
+.selected-lesson {
+  font-weight: bold;
+}
+.placeholder {
+  color: #999;
+  text-align: center;
+  width: 100%;
+  margin-top: 20px;
+}
+.resource-link {
+  margin-bottom: 8px;
+}
+</style>

--- a/src/components/ThinHeaderBar.vue
+++ b/src/components/ThinHeaderBar.vue
@@ -164,7 +164,7 @@ export default {
         this.alertMessage = this.$t('pleaseLoginToViewStudyPlan')
         return
       }
-      this.$emit('showStudyPlanDialog', true)
+      this.$router.push({ name: 'StudyPlanWorkspace' })
     },
 
     handleLanguageChange(val) {

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -18,6 +18,7 @@ import AboutUs from '@/components/AboutUs.vue'
 import ContactUs from '@/components/ContactUs.vue'
 import TestHeight from '@/components/TestHeight.vue'
 import StudyPlanDetail from '@/components/StudyPlanDetail.vue'
+import StudyPlanWorkspace from '@/components/StudyPlanWorkspace.vue'
 // import SearchBarVue from '@/components/search/SearchBar.vue'
 // import SearchResultItemVue from '@/components/search/SearchResultItem.vue'
 import SearchResultsVue from '@/components/search/SearchResults.vue'
@@ -51,6 +52,12 @@ const routes = [
     name: 'register',
     component: ReGister,
     meta: { layout: 'simplest' },
+  },
+  {
+    path: '/study-plans',
+    name: 'StudyPlanWorkspace',
+    component: StudyPlanWorkspace,
+    meta: { background: 'darker' },
   },
   {
     path: '/:userId',


### PR DESCRIPTION
## Summary
- add StudyPlanWorkspace component to show plans, steps, and lesson details in one view
- route study plan entry points to new workspace
- update list navigation to open workspace

## Testing
- `npm run lint` *(fails: Prettier formatting and lint errors throughout repository)*
- `npm run build` *(fails: Module not found: Can't resolve '@vueuse/core')*


------
https://chatgpt.com/codex/tasks/task_e_68ad6619c550832e8f35cd515904c360