### PR TITLE
feat: support background AI study plan generation

### DIFF
--- a/src/components/LayOut.vue
+++ b/src/components/LayOut.vue
@@ -35,6 +35,7 @@
           <LearningPlanner
             ref="learningPlanner"
             @update:showStudyPlan="handleShowStudyPlanUpdate"
+            @background="handleBackground"
           />
         </v-card-text>
         <v-card-actions>
@@ -53,6 +54,13 @@
         </v-card-actions>
       </v-card>
     </v-dialog>
+
+    <v-snackbar v-model="backgroundSnackbar" :timeout="backgroundLoading ? -1 : 3000">
+      <div class="d-flex align-center">
+        <v-progress-circular v-if="backgroundLoading" indeterminate color="white" class="mr-2" />
+        <span>{{ backgroundMessage }}</span>
+      </div>
+    </v-snackbar>
 
     <!-- 底部 -->
     <div class="footer-container">
@@ -98,6 +106,9 @@ export default {
       isSmallScreen: typeof window !== 'undefined' ? window.innerWidth <= 600 : false,
       mobileMenuOpen: false,
       searchBarVisible: false,
+      backgroundSnackbar: false,
+      backgroundMessage: '',
+      backgroundLoading: false,
     }
   },
   mounted() {
@@ -138,6 +149,27 @@ export default {
     handleDialogClick() { this.dialog = true },
     showSearchBar() { this.searchBarVisible = true },
     hideSearchBar() { this.searchBarVisible = false },
+    handleBackground(promise) {
+      this.dialog = false
+      this.showStudyPlan = false
+      this.backgroundMessage = 'AI 正在后台生成学习计划...'
+      this.backgroundSnackbar = true
+      this.backgroundLoading = true
+      promise
+        .then(() => {
+          this.backgroundMessage = 'AI 学习计划已生成'
+          this.backgroundLoading = false
+        })
+        .catch(() => {
+          this.backgroundMessage = 'AI 学习计划生成失败'
+          this.backgroundLoading = false
+        })
+        .finally(() => {
+          setTimeout(() => {
+            this.backgroundSnackbar = false
+          }, 3000)
+        })
+    },
   },
 }
 </script>

--- a/src/components/LearningPlanner.vue
+++ b/src/components/LearningPlanner.vue
@@ -12,7 +12,10 @@
     </button>
 
     <!-- Loader Spinner -->
-    <div v-if="loading" class="loader">{{ $t('studyplan.AIplaceholder') }}</div>
+    <div v-if="loading" class="loader">
+      {{ $t('studyplan.AIplaceholder') }}
+      <button class="ml-2" @click="runInBackground">后台运行</button>
+    </div>
 
     <study-plan
       v-if="showStudyPlan"
@@ -35,36 +38,49 @@ export default {
       learningObjective: '',
       showStudyPlan: false,
       studyPlanData: null,
-      loading: false, // Add this to track loading state
+      loading: false, // track loading state
+      currentRequest: null,
+      background: false,
     }
   },
   methods: {
     async generateStudyPlan() {
-      if (this.learningObjective) {
-        this.loading = true // Start loading
+      if (!this.learningObjective) return
+      this.loading = true
+      this.background = false
 
-        console.log('Generating study plan for:', this.learningObjective)
+      console.log('Generating study plan for:', this.learningObjective)
 
-        try {
-          const response = await pyApiClient.post('/studyplan', {
-            Name: this.learningObjective,
-          })
+      const request = pyApiClient.post('/studyplan', {
+        Name: this.learningObjective,
+      })
+      this.currentRequest = request
 
-          console.log('Study plan generated:', response)
+      try {
+        const response = await request
+        console.log('Study plan generated:', response)
 
-          if (response.status === 200) {
-            this.studyPlanData = response.data.StudyPlan // Set study plan data from the backend response
-            this.showStudyPlan = true // Display the study plan component
-            this.$emit('update:showStudyPlan', true) // Emit an event to the parent component
-            console.log('Study plan generated:', this.studyPlanData)
-          } else {
-            console.error('Failed to fetch the study plan:', response)
-          }
-        } catch (error) {
-          console.error('Error in fetching study plan:', error)
-        } finally {
-          this.loading = false // End loading
+        if (this.background) return // handled by parent when in background
+
+        if (response.status === 200) {
+          this.studyPlanData = response.data.StudyPlan
+          this.showStudyPlan = true
+          this.$emit('update:showStudyPlan', true)
+          console.log('Study plan generated:', this.studyPlanData)
+        } else {
+          console.error('Failed to fetch the study plan:', response)
         }
+      } catch (error) {
+        console.error('Error in fetching study plan:', error)
+      } finally {
+        this.loading = false
+        this.currentRequest = null
+      }
+    },
+    runInBackground() {
+      if (this.loading && this.currentRequest) {
+        this.background = true
+        this.$emit('background', this.currentRequest)
       }
     },
     async savePlan() {

--- a/src/components/StudyPlanWorkspace.vue
+++ b/src/components/StudyPlanWorkspace.vue
@@ -123,7 +123,7 @@
         <v-card-title class="text-h6">AI 学习计划生成器</v-card-title>
         <v-card-text>
           <!-- 子组件在任一输入变化时 $emit('dirty') -->
-          <LearningPlanner @dirty="aiDirty = true" />
+          <LearningPlanner @dirty="aiDirty = true" @background="handleBackground" />
         </v-card-text>
         <v-card-actions class="justify-end">
           <v-btn variant="text" @click="attemptClose('ai')">关闭</v-btn>
@@ -146,6 +146,13 @@
         </v-card-actions>
       </v-card>
     </v-dialog>
+
+    <v-snackbar v-model="backgroundSnackbar" :timeout="backgroundLoading ? -1 : 3000">
+      <div class="d-flex align-center">
+        <v-progress-circular v-if="backgroundLoading" indeterminate color="white" class="mr-2" />
+        <span>{{ backgroundMessage }}</span>
+      </div>
+    </v-snackbar>
 
   </v-container>
 </template>
@@ -171,6 +178,9 @@ export default {
       editPlan: null,
       aiDirty: false,
       editDirty: false,
+      backgroundSnackbar: false,
+      backgroundMessage: '',
+      backgroundLoading: false,
     }
   },
   async created() {
@@ -272,6 +282,28 @@ export default {
         this.editDialog = false
         this.editDirty = false
       }
+    },
+    handleBackground(promise) {
+      this.aiDialog = false
+      this.aiDirty = false
+      this.backgroundMessage = 'AI 正在后台生成学习计划...'
+      this.backgroundSnackbar = true
+      this.backgroundLoading = true
+      promise
+        .then(() => {
+          this.backgroundMessage = 'AI 学习计划已生成'
+          this.backgroundLoading = false
+          this.fetchPlans()
+        })
+        .catch(() => {
+          this.backgroundMessage = 'AI 学习计划生成失败'
+          this.backgroundLoading = false
+        })
+        .finally(() => {
+          setTimeout(() => {
+            this.backgroundSnackbar = false
+          }, 3000)
+        })
     }
   },
 }


### PR DESCRIPTION
## Summary
- allow LearningPlanner to run AI plan creation in background
- show snackbar notifications for background AI plan generation

## Testing
- `npm test` (fails: Missing script)
- `npm run lint` (fails: many prettier/prettier errors)


------
https://chatgpt.com/codex/tasks/task_e_68adb2af5588832e93f22dfbc9740951