### PR TITLE
feat: support background AI study plan generation

### DIFF
--- a/src/components/LayOut.vue
+++ b/src/components/LayOut.vue
@@ -35,6 +35,7 @@
           <LearningPlanner
             ref="learningPlanner"
             @update:showStudyPlan="handleShowStudyPlanUpdate"
+            @background="handleBackground"
           />
         </v-card-text>
         <v-card-actions>
@@ -53,6 +54,13 @@
         </v-card-actions>
       </v-card>
     </v-dialog>
+
+    <v-snackbar v-model="backgroundSnackbar" :timeout="-1" @click="onBackgroundSnackbarClick">
+      <div class="d-flex align-center">
+        <v-progress-circular v-if="backgroundLoading" indeterminate color="white" class="mr-2" />
+        <span>{{ backgroundMessage }}</span>
+      </div>
+    </v-snackbar>
 
     <!-- 底部 -->
     <div class="footer-container">
@@ -98,6 +106,10 @@ export default {
       isSmallScreen: typeof window !== 'undefined' ? window.innerWidth <= 600 : false,
       mobileMenuOpen: false,
       searchBarVisible: false,
+      backgroundSnackbar: false,
+      backgroundMessage: '',
+      backgroundLoading: false,
+      backgroundSuccess: false,
     }
   },
   mounted() {
@@ -106,6 +118,7 @@ export default {
 
     eventBus.on('show-search-bar', this.showSearchBar)
     eventBus.on('hide-search-bar', this.hideSearchBar)
+    eventBus.on('background-plan', this.handleBackground)
 
     document.body.classList.add('sidebar-layout')
   },
@@ -113,6 +126,7 @@ export default {
     window.removeEventListener('resize', this.handleResize)
     eventBus.off('show-search-bar', this.showSearchBar)
     eventBus.off('hide-search-bar', this.hideSearchBar)
+    eventBus.off('background-plan', this.handleBackground)
     document.body.classList.remove('sidebar-layout')
   },
   methods: {
@@ -135,9 +149,44 @@ export default {
     triggerSavePlan() { this.$refs.learningPlanner?.savePlan?.() },
     closeDialog() { this.showStudyPlan = false; this.dialog = false },
     handleShowStudyPlanUpdate(v) { this.showStudyPlan = v },
-    handleDialogClick() { this.dialog = true },
+    handleDialogClick() {
+      if (this.$store.state.backgroundGenerating) {
+        alert('AI 正在生成学习计划，请稍后再试')
+        return
+      }
+      this.dialog = true
+    },
     showSearchBar() { this.searchBarVisible = true },
     hideSearchBar() { this.searchBarVisible = false },
+    handleBackground(promise) {
+      this.dialog = false
+      this.showStudyPlan = false
+      this.backgroundMessage = 'AI 正在后台生成学习计划...'
+      this.backgroundSnackbar = true
+      this.backgroundLoading = true
+      this.backgroundSuccess = false
+      this.$store.commit('SET_BACKGROUND_GENERATING', true)
+      promise
+        .then(() => {
+          this.backgroundMessage = 'AI 学习计划已生成，点击查看'
+          this.backgroundSuccess = true
+        })
+        .catch(() => {
+          this.backgroundMessage = 'AI 学习计划生成失败，点击关闭'
+          this.backgroundSuccess = false
+        })
+        .finally(() => {
+          this.backgroundLoading = false
+          this.$store.commit('SET_BACKGROUND_GENERATING', false)
+        })
+    },
+    onBackgroundSnackbarClick() {
+      if (this.backgroundLoading) return
+      this.backgroundSnackbar = false
+      if (this.backgroundSuccess) {
+        this.$router.push({ name: 'StudyPlanWorkspace' })
+      }
+    },
   },
 }
 </script>

--- a/src/components/LearningPlanner.vue
+++ b/src/components/LearningPlanner.vue
@@ -7,12 +7,15 @@
       :placeholder="$t('studyplan.placeholder')"
       @update:model-value="$emit('dirty')"
     />
-    <button :disabled="!learningObjective" @click="generateStudyPlan">
+    <button :disabled="!learningObjective || $store.state.backgroundGenerating" @click="generateStudyPlan">
       {{ $t('studyplan.startcustomizing') }}
     </button>
 
     <!-- Loader Spinner -->
-    <div v-if="loading" class="loader">{{ $t('studyplan.AIplaceholder') }}</div>
+    <div v-if="loading" class="loader">
+      {{ $t('studyplan.AIplaceholder') }}
+      <button class="ml-2" @click="runInBackground">后台运行</button>
+    </div>
 
     <study-plan
       v-if="showStudyPlan"
@@ -35,36 +38,53 @@ export default {
       learningObjective: '',
       showStudyPlan: false,
       studyPlanData: null,
-      loading: false, // Add this to track loading state
+      loading: false, // track loading state
+      currentRequest: null,
+      background: false,
     }
   },
   methods: {
     async generateStudyPlan() {
-      if (this.learningObjective) {
-        this.loading = true // Start loading
+      if (!this.learningObjective) return
+      if (this.$store.state.backgroundGenerating) {
+        alert('AI 正在生成学习计划，请稍后再试')
+        return
+      }
+      this.loading = true
+      this.background = false
 
-        console.log('Generating study plan for:', this.learningObjective)
+      console.log('Generating study plan for:', this.learningObjective)
 
-        try {
-          const response = await pyApiClient.post('/studyplan', {
-            Name: this.learningObjective,
-          })
+      const request = pyApiClient.post('/studyplan', {
+        Name: this.learningObjective,
+      })
+      this.currentRequest = request
 
-          console.log('Study plan generated:', response)
+      try {
+        const response = await request
+        console.log('Study plan generated:', response)
 
-          if (response.status === 200) {
-            this.studyPlanData = response.data.StudyPlan // Set study plan data from the backend response
-            this.showStudyPlan = true // Display the study plan component
-            this.$emit('update:showStudyPlan', true) // Emit an event to the parent component
-            console.log('Study plan generated:', this.studyPlanData)
-          } else {
-            console.error('Failed to fetch the study plan:', response)
-          }
-        } catch (error) {
-          console.error('Error in fetching study plan:', error)
-        } finally {
-          this.loading = false // End loading
+        if (this.background) return // handled by parent when in background
+
+        if (response.status === 200) {
+          this.studyPlanData = response.data.StudyPlan
+          this.showStudyPlan = true
+          this.$emit('update:showStudyPlan', true)
+          console.log('Study plan generated:', this.studyPlanData)
+        } else {
+          console.error('Failed to fetch the study plan:', response)
         }
+      } catch (error) {
+        console.error('Error in fetching study plan:', error)
+      } finally {
+        this.loading = false
+        this.currentRequest = null
+      }
+    },
+    runInBackground() {
+      if (this.loading && this.currentRequest) {
+        this.background = true
+        this.$emit('background', this.currentRequest)
       }
     },
     async savePlan() {

--- a/src/components/StudyPlanWorkspace.vue
+++ b/src/components/StudyPlanWorkspace.vue
@@ -7,8 +7,8 @@
           <div class="plan-list-header d-flex align-center px-4 py-2">
             <span class="text-h6">我的学习计划</span>
             <v-spacer />
-            <v-btn icon="mdi-plus" variant="text" @click="openCreateDialog" />
-            <v-btn icon="mdi-robot-outline" variant="text" @click="aiDialog = true" />
+            <v-btn icon="mdi-plus" variant="text" @click="openCreateDialog" :disabled="backgroundGenerating" />
+            <v-btn icon="mdi-robot-outline" variant="text" @click="openAiDialog" :disabled="backgroundGenerating" />
           </div>
           <v-divider />
           <template v-if="studyPlans.length">
@@ -27,10 +27,10 @@
           </template>
           <div v-else class="empty-plan-list text-center px-4">
             <p class="mb-4">你还没有创建学习计划</p>
-            <v-btn block class="mb-2" color="primary" @click="openCreateDialog">
+            <v-btn block class="mb-2" color="primary" @click="openCreateDialog" :disabled="backgroundGenerating">
               新建学习计划
             </v-btn>
-            <v-btn block color="secondary" @click="aiDialog = true">
+            <v-btn block color="secondary" @click="openAiDialog" :disabled="backgroundGenerating">
               AI 生成计划
             </v-btn>
           </div>
@@ -123,7 +123,7 @@
         <v-card-title class="text-h6">AI 学习计划生成器</v-card-title>
         <v-card-text>
           <!-- 子组件在任一输入变化时 $emit('dirty') -->
-          <LearningPlanner @dirty="aiDirty = true" />
+          <LearningPlanner @dirty="aiDirty = true" @background="handleBackground" />
         </v-card-text>
         <v-card-actions class="justify-end">
           <v-btn variant="text" @click="attemptClose('ai')">关闭</v-btn>
@@ -154,6 +154,7 @@
 import { apiClient } from '@/api'
 import LearningPlanner from '@/components/LearningPlanner.vue'
 import EditStudyPlanForm from '@/components/EditStudyPlanForm.vue'
+import { eventBus } from '@/eventBus'
 
 export default {
   name: 'StudyPlanWorkspace',
@@ -172,6 +173,11 @@ export default {
       aiDirty: false,
       editDirty: false,
     }
+  },
+  computed: {
+    backgroundGenerating() {
+      return this.$store.state.backgroundGenerating
+    },
   },
   async created() {
     await this.fetchPlans()
@@ -202,6 +208,10 @@ export default {
       this.currentLesson = lesson
     },
     openCreateDialog() {
+      if (this.backgroundGenerating) {
+        alert('AI 正在生成学习计划，请稍后再试')
+        return
+      }
       this.editPlan = {
         title: '',
         introduction: { description: '' },
@@ -211,6 +221,13 @@ export default {
       }
       this.editDirty = false
       this.editDialog = true
+    },
+    openAiDialog() {
+      if (this.backgroundGenerating) {
+        alert('AI 正在生成学习计划，请稍后再试')
+        return
+      }
+      this.aiDialog = true
     },
     async saveStudyPlan(plan) {
       try {
@@ -272,7 +289,13 @@ export default {
         this.editDialog = false
         this.editDirty = false
       }
-    }
+    },
+    handleBackground(promise) {
+      this.aiDialog = false
+      this.aiDirty = false
+      eventBus.emit('background-plan', promise)
+      promise.then(() => this.fetchPlans())
+    },
   },
 }
 </script>

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -26,6 +26,7 @@ export default createStore({
     conversationMessageCount: {},
     notificationCount: 0,
     learningStatus: {},
+    backgroundGenerating: false,
   },
   mutations: {
     SET_AUTHENTICATED(state, value) {
@@ -119,6 +120,9 @@ export default createStore({
     },
     SET_LEARNING_STATUS(state, { lessonName, resourceLink, learned }) {
       state.learningStatus[`${lessonName}-${resourceLink}`] = learned
+    },
+    SET_BACKGROUND_GENERATING(state, value) {
+      state.backgroundGenerating = value
     },
   },
   actions: {


### PR DESCRIPTION
## Summary
- allow LearningPlanner to run AI plan creation in background
- show snackbar notifications for background AI plan generation that persist across navigation
- block new study-plan generation while a background request is in progress

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: prettier/prettier, no-unused-vars errors)


------
https://chatgpt.com/codex/tasks/task_e_68adb2af5588832e93f22dfbc9740951