### PR TITLE
Auto save AI study plan results and open them

### DIFF
--- a/src/components/LayOut.vue
+++ b/src/components/LayOut.vue
@@ -35,6 +35,7 @@
           <LearningPlanner
             ref="learningPlanner"
             @update:showStudyPlan="handleShowStudyPlanUpdate"
+            @background="handleBackground"
           />
         </v-card-text>
         <v-card-actions>
@@ -54,10 +55,25 @@
       </v-card>
     </v-dialog>
 
+    <v-snackbar
+      v-model="backgroundSnackbar"
+      :timeout="-1"
+      @click="onBackgroundSnackbarClick"
+    >
+      <div class="d-flex align-center">
+        <v-progress-circular
+          v-if="backgroundLoading"
+          indeterminate
+          color="white"
+          class="mr-2"
+        />
+        <span>{{ backgroundMessage }}</span>
+      </div>
+    </v-snackbar>
+
     <!-- 底部 -->
     <div class="footer-container">
-      <transition
-        name="footer-transition">
+      <transition name="footer-transition">
         <v-footer app v-if="!showFinalFooter" class="dynamic-footer">
           <FooterBar />
         </v-footer>
@@ -78,6 +94,7 @@ import FooterBar from './FooterBar.vue'
 // import DefaultFooterBar from './DefaultFooterBar.vue'
 import ScrollToTopButton from './ScrollToTopButton.vue'
 import { eventBus } from '@/eventBus'
+import { apiClient } from '@/api'
 
 export default {
   name: 'LayOut',
@@ -95,9 +112,15 @@ export default {
       dialog: false,
       showStudyPlan: false,
       showFinalFooter: false,
-      isSmallScreen: typeof window !== 'undefined' ? window.innerWidth <= 600 : false,
+      isSmallScreen:
+        typeof window !== 'undefined' ? window.innerWidth <= 600 : false,
       mobileMenuOpen: false,
       searchBarVisible: false,
+      backgroundSnackbar: false,
+      backgroundMessage: '',
+      backgroundLoading: false,
+      backgroundSuccess: false,
+      generatedPlanId: null,
     }
   },
   mounted() {
@@ -106,6 +129,7 @@ export default {
 
     eventBus.on('show-search-bar', this.showSearchBar)
     eventBus.on('hide-search-bar', this.hideSearchBar)
+    eventBus.on('background-plan', this.handleBackground)
 
     document.body.classList.add('sidebar-layout')
   },
@@ -113,6 +137,7 @@ export default {
     window.removeEventListener('resize', this.handleResize)
     eventBus.off('show-search-bar', this.showSearchBar)
     eventBus.off('hide-search-bar', this.hideSearchBar)
+    eventBus.off('background-plan', this.handleBackground)
     document.body.classList.remove('sidebar-layout')
   },
   methods: {
@@ -121,7 +146,8 @@ export default {
 
       const header = document.querySelector('.large-header')
       if (header) {
-        if (this.isSmallScreen && this.mobileMenuOpen) header.classList.add('menu-open')
+        if (this.isSmallScreen && this.mobileMenuOpen)
+          header.classList.add('menu-open')
         else header.classList.remove('menu-open')
       }
     },
@@ -132,12 +158,80 @@ export default {
       if (header) header.classList.toggle('menu-open')
       if (logo) logo.classList.toggle('menu-open')
     },
-    triggerSavePlan() { this.$refs.learningPlanner?.savePlan?.() },
-    closeDialog() { this.showStudyPlan = false; this.dialog = false },
-    handleShowStudyPlanUpdate(v) { this.showStudyPlan = v },
-    handleDialogClick() { this.dialog = true },
-    showSearchBar() { this.searchBarVisible = true },
-    hideSearchBar() { this.searchBarVisible = false },
+    triggerSavePlan() {
+      this.$refs.learningPlanner?.savePlan?.()
+    },
+    closeDialog() {
+      this.showStudyPlan = false
+      this.dialog = false
+    },
+    handleShowStudyPlanUpdate(v) {
+      this.showStudyPlan = v
+    },
+    handleDialogClick() {
+      if (this.$store.state.backgroundGenerating) {
+        alert('AI 正在生成学习计划，请稍后再试')
+        return
+      }
+      this.dialog = true
+    },
+    showSearchBar() {
+      this.searchBarVisible = true
+    },
+    hideSearchBar() {
+      this.searchBarVisible = false
+    },
+    handleBackground(promise) {
+      this.dialog = false
+      this.showStudyPlan = false
+      this.backgroundMessage = 'AI 正在后台生成学习计划...'
+      this.backgroundSnackbar = true
+      this.backgroundLoading = true
+      this.backgroundSuccess = false
+      this.generatedPlanId = null
+      this.$store.commit('SET_BACKGROUND_GENERATING', true)
+      promise
+        .then(async (res) => {
+          try {
+            const studyPlan = res.data?.StudyPlan
+            if (studyPlan) {
+              const saveRes = await apiClient.post('/StudyPlan/SaveStudyPlan', {
+                studyPlan,
+              })
+              this.generatedPlanId =
+                saveRes.data?.id || saveRes.data?.studyPlan?.id || null
+            }
+            this.backgroundMessage = 'AI 学习计划已生成，点击查看'
+            this.backgroundSuccess = true
+          } catch (e) {
+            console.error('Error saving background study plan:', e)
+            this.backgroundMessage = 'AI 学习计划生成失败，点击关闭'
+            this.backgroundSuccess = false
+          }
+        })
+        .catch(() => {
+          this.backgroundMessage = 'AI 学习计划生成失败，点击关闭'
+          this.backgroundSuccess = false
+        })
+        .finally(() => {
+          this.backgroundLoading = false
+          this.$store.commit('SET_BACKGROUND_GENERATING', false)
+        })
+    },
+    onBackgroundSnackbarClick() {
+      if (this.backgroundLoading) return
+      this.backgroundSnackbar = false
+      if (this.backgroundSuccess) {
+        const route = {
+          name: 'StudyPlanWorkspace',
+          params: { userId: this.$store.state.currentUserID },
+        }
+        if (this.generatedPlanId) {
+          route.query = { planId: this.generatedPlanId }
+        }
+        this.$router.push(route)
+      }
+    },
   },
 }
 </script>
@@ -156,12 +250,11 @@ export default {
   额外留一个安全间距 gap = 16px。
 */
 .layout-wrapper {
-  --sidebar-left: 16px;     /* = .large-header 的 left */
-  --sidebar-width: 70px;    /* = .large-header 的 width */
-  --sidebar-gap: 16px;      /* 主内容与侧栏额外间距 */
+  --sidebar-left: 16px; /* = .large-header 的 left */
+  --sidebar-width: 70px; /* = .large-header 的 width */
+  --sidebar-gap: 16px; /* 主内容与侧栏额外间距 */
   --sidebar-reserved: calc(
-    var(--sidebar-left, 16px) + 
-    var(--sidebar-width, 70px)
+    var(--sidebar-left, 16px) + var(--sidebar-width, 70px)
   );
 }
 
@@ -190,7 +283,7 @@ export default {
 /* 主内容占据剩余空间 */
 .main-content {
   flex: 1 1 auto;
-  min-width: 0;                 /* 防止溢出 */
+  min-width: 0; /* 防止溢出 */
   box-sizing: border-box;
   padding: var(--content-padding, 16px);
   /* background: white; */
@@ -198,9 +291,16 @@ export default {
 
 /* 移动端：主内容全宽，不再预留侧栏 */
 @media (max-width: 600px) {
-  .body-wrapper { flex-direction: column; }
-  .sidebar-slot { display: none; }
-  .main-content { --content-padding: 8px; width: 100%; }
+  .body-wrapper {
+    flex-direction: column;
+  }
+  .sidebar-slot {
+    display: none;
+  }
+  .main-content {
+    --content-padding: 8px;
+    width: 100%;
+  }
 }
 
 /* 移动端汉堡按钮（保留你的样式） */
@@ -216,20 +316,26 @@ export default {
   display: none;
   align-items: center;
   justify-content: center;
-  box-shadow: 0 2px 8px rgba(0,0,0,.2);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
   cursor: pointer;
 }
 @media (max-width: 600px) {
-  .menu-toggle { display: flex; }
+  .menu-toggle {
+    display: flex;
+  }
 }
 
 /* 底部动画与配色（保持原样） */
-.footer-transition-enter-active { animation: footer-bounce-in .4s ease-out; }
-.footer-transition-leave-active { animation: footer-bounce-out .4s ease-out; }
+.footer-transition-enter-active {
+  animation: footer-bounce-in 0.4s ease-out;
+}
+.footer-transition-leave-active {
+  animation: footer-bounce-out 0.4s ease-out;
+}
 
 .dynamic-footer {
   height: var(--footer-vh, 6vh);
-  width: calc(100% - 32px)!important;
+  width: calc(100% - 32px) !important;
   background-color: rgba(232, 218, 189);
   margin-left: 16px;
   margin-right: 16px;
@@ -240,11 +346,23 @@ export default {
 }
 
 @keyframes footer-bounce-in {
-  0% { transform: translateY(120%); opacity: 0; }
-  100% { transform: translateY(0); opacity: 1; }
+  0% {
+    transform: translateY(120%);
+    opacity: 0;
+  }
+  100% {
+    transform: translateY(0);
+    opacity: 1;
+  }
 }
 @keyframes footer-bounce-out {
-  0% { transform: translateY(0); opacity: 1; }
-  100% { transform: translateY(120%); opacity: 0; }
+  0% {
+    transform: translateY(0);
+    opacity: 1;
+  }
+  100% {
+    transform: translateY(120%);
+    opacity: 0;
+  }
 }
 </style>

--- a/src/components/LearningPlanner.vue
+++ b/src/components/LearningPlanner.vue
@@ -7,12 +7,15 @@
       :placeholder="$t('studyplan.placeholder')"
       @update:model-value="$emit('dirty')"
     />
-    <button :disabled="!learningObjective" @click="generateStudyPlan">
+    <button :disabled="!learningObjective || $store.state.backgroundGenerating" @click="generateStudyPlan">
       {{ $t('studyplan.startcustomizing') }}
     </button>
 
     <!-- Loader Spinner -->
-    <div v-if="loading" class="loader">{{ $t('studyplan.AIplaceholder') }}</div>
+    <div v-if="loading" class="loader">
+      {{ $t('studyplan.AIplaceholder') }}
+      <button class="ml-2" @click="runInBackground">后台运行</button>
+    </div>
 
     <study-plan
       v-if="showStudyPlan"
@@ -35,36 +38,53 @@ export default {
       learningObjective: '',
       showStudyPlan: false,
       studyPlanData: null,
-      loading: false, // Add this to track loading state
+      loading: false, // track loading state
+      currentRequest: null,
+      background: false,
     }
   },
   methods: {
     async generateStudyPlan() {
-      if (this.learningObjective) {
-        this.loading = true // Start loading
+      if (!this.learningObjective) return
+      if (this.$store.state.backgroundGenerating) {
+        alert('AI 正在生成学习计划，请稍后再试')
+        return
+      }
+      this.loading = true
+      this.background = false
 
-        console.log('Generating study plan for:', this.learningObjective)
+      console.log('Generating study plan for:', this.learningObjective)
 
-        try {
-          const response = await pyApiClient.post('/studyplan', {
-            Name: this.learningObjective,
-          })
+      const request = pyApiClient.post('/studyplan', {
+        Name: this.learningObjective,
+      })
+      this.currentRequest = request
 
-          console.log('Study plan generated:', response)
+      try {
+        const response = await request
+        console.log('Study plan generated:', response)
 
-          if (response.status === 200) {
-            this.studyPlanData = response.data.StudyPlan // Set study plan data from the backend response
-            this.showStudyPlan = true // Display the study plan component
-            this.$emit('update:showStudyPlan', true) // Emit an event to the parent component
-            console.log('Study plan generated:', this.studyPlanData)
-          } else {
-            console.error('Failed to fetch the study plan:', response)
-          }
-        } catch (error) {
-          console.error('Error in fetching study plan:', error)
-        } finally {
-          this.loading = false // End loading
+        if (this.background) return // handled by parent when in background
+
+        if (response.status === 200) {
+          this.studyPlanData = response.data.StudyPlan
+          this.showStudyPlan = true
+          this.$emit('update:showStudyPlan', true)
+          console.log('Study plan generated:', this.studyPlanData)
+        } else {
+          console.error('Failed to fetch the study plan:', response)
         }
+      } catch (error) {
+        console.error('Error in fetching study plan:', error)
+      } finally {
+        this.loading = false
+        this.currentRequest = null
+      }
+    },
+    runInBackground() {
+      if (this.loading && this.currentRequest) {
+        this.background = true
+        this.$emit('background', this.currentRequest)
       }
     },
     async savePlan() {

--- a/src/components/StudyPlanWorkspace.vue
+++ b/src/components/StudyPlanWorkspace.vue
@@ -7,8 +7,8 @@
           <div class="plan-list-header d-flex align-center px-4 py-2">
             <span class="text-h6">我的学习计划</span>
             <v-spacer />
-            <v-btn icon="mdi-plus" variant="text" @click="openCreateDialog" />
-            <v-btn icon="mdi-robot-outline" variant="text" @click="aiDialog = true" />
+            <v-btn icon="mdi-plus" variant="text" @click="openCreateDialog" :disabled="backgroundGenerating" />
+            <v-btn icon="mdi-robot-outline" variant="text" @click="openAiDialog" :disabled="backgroundGenerating" />
           </div>
           <v-divider />
           <template v-if="studyPlans.length">
@@ -27,10 +27,10 @@
           </template>
           <div v-else class="empty-plan-list text-center px-4">
             <p class="mb-4">你还没有创建学习计划</p>
-            <v-btn block class="mb-2" color="primary" @click="openCreateDialog">
+            <v-btn block class="mb-2" color="primary" @click="openCreateDialog" :disabled="backgroundGenerating">
               新建学习计划
             </v-btn>
-            <v-btn block color="secondary" @click="aiDialog = true">
+            <v-btn block color="secondary" @click="openAiDialog" :disabled="backgroundGenerating">
               AI 生成计划
             </v-btn>
           </div>
@@ -123,7 +123,7 @@
         <v-card-title class="text-h6">AI 学习计划生成器</v-card-title>
         <v-card-text>
           <!-- 子组件在任一输入变化时 $emit('dirty') -->
-          <LearningPlanner @dirty="aiDirty = true" />
+          <LearningPlanner @dirty="aiDirty = true" @background="handleBackground" />
         </v-card-text>
         <v-card-actions class="justify-end">
           <v-btn variant="text" @click="attemptClose('ai')">关闭</v-btn>
@@ -154,6 +154,7 @@
 import { apiClient } from '@/api'
 import LearningPlanner from '@/components/LearningPlanner.vue'
 import EditStudyPlanForm from '@/components/EditStudyPlanForm.vue'
+import { eventBus } from '@/eventBus'
 
 export default {
   name: 'StudyPlanWorkspace',
@@ -173,6 +174,11 @@ export default {
       editDirty: false,
     }
   },
+  computed: {
+    backgroundGenerating() {
+      return this.$store.state.backgroundGenerating
+    },
+  },
   async created() {
     await this.fetchPlans()
     const planId = this.$route.query.planId
@@ -189,10 +195,34 @@ export default {
     async fetchPlans() {
       try {
         const res = await apiClient.get('/StudyPlan/FetchStudyPlans')
-        this.studyPlans = res.data
+        this.studyPlans = res.data.map((p) => {
+          const sections = ['prerequisite', 'mainCurriculum', 'advancedTopics']
+          sections.forEach((sec) => {
+            if (p.studyPlan[sec]) {
+              p.studyPlan[sec] = this.mergeLessons(p.studyPlan[sec])
+            }
+          })
+          return p
+        })
       } catch (e) {
         console.error('Error fetching study plans:', e)
       }
+    },
+    mergeLessons(lessons) {
+      const map = new Map()
+      lessons.forEach((lesson) => {
+        const existing = map.get(lesson.name)
+        if (existing) {
+          const resources = lesson.resources || []
+          existing.resources = existing.resources.concat(resources)
+        } else {
+          map.set(lesson.name, {
+            ...lesson,
+            resources: lesson.resources ? [...lesson.resources] : [],
+          })
+        }
+      })
+      return Array.from(map.values())
     },
     selectPlan(plan) {
       this.currentPlan = plan
@@ -202,6 +232,10 @@ export default {
       this.currentLesson = lesson
     },
     openCreateDialog() {
+      if (this.backgroundGenerating) {
+        alert('AI 正在生成学习计划，请稍后再试')
+        return
+      }
       this.editPlan = {
         title: '',
         introduction: { description: '' },
@@ -211,6 +245,13 @@ export default {
       }
       this.editDirty = false
       this.editDialog = true
+    },
+    openAiDialog() {
+      if (this.backgroundGenerating) {
+        alert('AI 正在生成学习计划，请稍后再试')
+        return
+      }
+      this.aiDialog = true
     },
     async saveStudyPlan(plan) {
       try {
@@ -272,7 +313,13 @@ export default {
         this.editDialog = false
         this.editDirty = false
       }
-    }
+    },
+    handleBackground(promise) {
+      this.aiDialog = false
+      this.aiDirty = false
+      eventBus.emit('background-plan', promise)
+      promise.then(() => this.fetchPlans())
+    },
   },
 }
 </script>

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -26,6 +26,7 @@ export default createStore({
     conversationMessageCount: {},
     notificationCount: 0,
     learningStatus: {},
+    backgroundGenerating: false,
   },
   mutations: {
     SET_AUTHENTICATED(state, value) {
@@ -119,6 +120,9 @@ export default createStore({
     },
     SET_LEARNING_STATUS(state, { lessonName, resourceLink, learned }) {
       state.learningStatus[`${lessonName}-${resourceLink}`] = learned
+    },
+    SET_BACKGROUND_GENERATING(state, value) {
+      state.backgroundGenerating = value
     },
   },
   actions: {


### PR DESCRIPTION
## Summary
- Automatically save AI-generated study plans when they run in the background
- Record the new plan ID and navigate to StudyPlanWorkspace with it once generation finishes
- Route to StudyPlanWorkspace with the current user ID and select the generated plan
- Consolidate lessons so each appears once even if it has multiple resources

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: numerous prettier/no-unused-vars errors in repository)*

------
https://chatgpt.com/codex/tasks/task_e_68adb2af5588832e93f22dfbc9740951